### PR TITLE
Update utils.h to fix bug error in ArchLinux

### DIFF
--- a/include/toolbox/data/utils.h
+++ b/include/toolbox/data/utils.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+#include <cstdint>
 
 namespace toolbox {
 namespace data {


### PR DESCRIPTION
When build on ArchLinux it have error: [  1%] Building CXX object _deps/toolbox-build/CMakeFiles/toolbox.dir/src/data/bytes_data.cpp.o
In file included from /home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/basic_data.h:12,
                 from /home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/bytes_data.h:13,
                 from /home/Aptos-Cpp-SDK/build/_deps/toolbox-src/src/data/bytes_data.cpp:9:
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:22:25: error: ‘uint8_t’ was not declared in this scope
   22 | TOOLBOX_API std::vector<uint8_t> hex_to_bytes(const std::string& hex);
      |                         ^~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:15:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   14 | #include <vector>
  +++ |+#include <cstdint>
   15 | 
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:22:32: error: template argument 1 is invalid
   22 | TOOLBOX_API std::vector<uint8_t> hex_to_bytes(const std::string& hex);
      |                                ^
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:22:32: error: template argument 2 is invalid
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:28:44: error: ‘uint8_t’ does not name a type
   28 | TOOLBOX_API std::string bytes_to_hex(const uint8_t* data, size_t len);
      |                                            ^~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:28:44: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:35:47: error: ‘uint8_t’ was not declared in this scope
   35 | void num_to_bytes(const NumT num, std::vector<uint8_t>& out) {
      |                                               ^~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:35:47: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:35:54: error: template argument 1 is invalid
   35 | void num_to_bytes(const NumT num, std::vector<uint8_t>& out) {
      |                                                      ^
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:35:54: error: template argument 2 is invalid
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h: In function ‘void toolbox::data::num_to_bytes(NumT, int&)’:
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:40:18: error: request for member ‘size’ in ‘out’, which is of non-class type ‘int’
   40 |         out[(out.size() - 1) - i] = (num >> (i * 8));
      |                  ^~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h: At global scope:
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:45:13: error: ‘uint8_t’ was not declared in this scope
   45 | std::vector<uint8_t> num_to_bytes(NumT num) {
      |             ^~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:45:13: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:45:20: error: template argument 1 is invalid
   45 | std::vector<uint8_t> num_to_bytes(NumT num) {
      |                    ^
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:45:20: error: template argument 2 is invalid
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h: In function ‘int toolbox::data::num_to_bytes(NumT)’:
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:46:17: error: ‘uint8_t’ was not declared in this scope
   46 |     std::vector<uint8_t> out(sizeof(num));
      |                 ^~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:46:17: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:46:24: error: template argument 1 is invalid
   46 |     std::vector<uint8_t> out(sizeof(num));
      |                        ^
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:46:24: error: template argument 2 is invalid
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h: At global scope:
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:52:13: error: ‘uint8_t’ was not declared in this scope
   52 | std::vector<uint8_t> num_to_bytes(NumT num, size_t outSize) {
      |             ^~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:52:13: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:52:20: error: template argument 1 is invalid
   52 | std::vector<uint8_t> num_to_bytes(NumT num, size_t outSize) {
      |                    ^
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:52:20: error: template argument 2 is invalid
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h: In function ‘int toolbox::data::num_to_bytes(NumT, size_t)’:
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:54:17: error: ‘uint8_t’ was not declared in this scope
   54 |     std::vector<uint8_t> out(outSize);
      |                 ^~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:54:17: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:54:24: error: template argument 1 is invalid
   54 |     std::vector<uint8_t> out(outSize);
      |                        ^
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:54:24: error: template argument 2 is invalid
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h: At global scope:
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:60:52: error: ‘uint8_t’ was not declared in this scope
   60 | TOOLBOX_API std::string to_ascii(const std::vector<uint8_t>& input);
      |                                                    ^~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:60:52: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:60:59: error: template argument 1 is invalid
   60 | TOOLBOX_API std::string to_ascii(const std::vector<uint8_t>& input);
      |                                                           ^
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:60:59: error: template argument 2 is invalid
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:62:58: error: ‘uint8_t’ was not declared in this scope
   62 | TOOLBOX_API std::vector<char> to_chars(const std::vector<uint8_t>& input);
      |                                                          ^~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:62:58: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:62:65: error: template argument 1 is invalid
   62 | TOOLBOX_API std::vector<char> to_chars(const std::vector<uint8_t>& input);
      |                                                                 ^
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:62:65: error: template argument 2 is invalid
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:63:25: error: ‘uint8_t’ was not declared in this scope
   63 | TOOLBOX_API std::vector<uint8_t> to_bytes(const std::vector<char>& input);
      |                         ^~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:63:25: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:63:32: error: template argument 1 is invalid
   63 | TOOLBOX_API std::vector<uint8_t> to_bytes(const std::vector<char>& input);
      |                                ^
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:63:32: error: template argument 2 is invalid
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:64:25: error: ‘uint8_t’ was not declared in this scope
   64 | TOOLBOX_API std::vector<uint8_t> to_bytes(const char* data, size_t len);
      |                         ^~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:64:25: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:64:32: error: template argument 1 is invalid
   64 | TOOLBOX_API std::vector<uint8_t> to_bytes(const char* data, size_t len);
      |                                ^
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:64:32: error: template argument 2 is invalid
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:65:25: error: ‘uint8_t’ was not declared in this scope
   65 | TOOLBOX_API std::vector<uint8_t> to_bytes(std::string input);
      |                         ^~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:65:25: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:65:32: error: template argument 1 is invalid
   65 | TOOLBOX_API std::vector<uint8_t> to_bytes(std::string input);
      |                                ^
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:65:32: error: template argument 2 is invalid
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/src/data/bytes_data.cpp: In static member function ‘static toolbox::data::bytes_data toolbox::data::bytes_data::from_chars(const std::vector<char>&)’:
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/src/data/bytes_data.cpp:22:35: error: invalid conversion from ‘int’ to ‘const char*’ [-fpermissive]
   22 |     return toolbox::data::to_bytes(data);
      |            ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
      |                                   |
      |                                   int
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/bytes_data.h:42:28: note:   initializing argument 1 of ‘toolbox::data::bytes_data::bytes_data(const char*)’
   42 |     bytes_data(const char* hexString);
      |                ~~~~~~~~~~~~^~~~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/src/data/bytes_data.cpp: In static member function ‘static toolbox::data::bytes_data toolbox::data::bytes_data::from_chars(const char*, size_t)’:
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/src/data/bytes_data.cpp:26:35: error: invalid conversion from ‘int’ to ‘const char*’ [-fpermissive]
   26 |     return toolbox::data::to_bytes(data, len);
      |            ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
      |                                   |
      |                                   int
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/bytes_data.h:42:28: note:   initializing argument 1 of ‘toolbox::data::bytes_data::bytes_data(const char*)’
   42 |     bytes_data(const char* hexString);
      |                ~~~~~~~~~~~~^~~~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/src/data/bytes_data.cpp: In static member function ‘static toolbox::data::bytes_data toolbox::data::bytes_data::from_string_raw(const std::string&)’:
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/src/data/bytes_data.cpp:30:35: error: invalid conversion from ‘int’ to ‘const char*’ [-fpermissive]
   30 |     return toolbox::data::to_bytes(data);
      |            ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
      |                                   |
      |                                   int
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/bytes_data.h:42:28: note:   initializing argument 1 of ‘toolbox::data::bytes_data::bytes_data(const char*)’
   42 |     bytes_data(const char* hexString);
      |                ~~~~~~~~~~~~^~~~~~~~~
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/src/data/bytes_data.cpp: In member function ‘virtual std::string toolbox::data::bytes_data::to_hex() const’:
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/src/data/bytes_data.cpp:66:29: error: cannot convert ‘const unsigned char*’ to ‘const int*’
   66 |     return bytes_to_hex(data(), size());
      |                         ~~~~^~
      |                             |
      |                             const unsigned char*
/home/Aptos-Cpp-SDK/build/_deps/toolbox-src/include/toolbox/data/utils.h:28:53: note:   initializing argument 1 of ‘std::string toolbox::data::bytes_to_hex(const int*, size_t)’
   28 | TOOLBOX_API std::string bytes_to_hex(const uint8_t* data, size_t len);